### PR TITLE
Fixing unescaped forwarded parameters

### DIFF
--- a/src/aurman/classes.py
+++ b/src/aurman/classes.py
@@ -1118,7 +1118,7 @@ class Package:
             raise InvalidInput("package file of {} not available".format(self.name))
 
         # install
-        pacman(args_as_list.extend([package_install_file]), False, dir_to_execute=build_dir)
+        pacman(args_as_list + [package_install_file], False, dir_to_execute=build_dir)
 
 
 class System:

--- a/src/aurman/classes.py
+++ b/src/aurman/classes.py
@@ -1101,11 +1101,11 @@ class Package:
         if self.get_package_file_to_install(build_dir, build_version) is None:
             makepkg("-cf --noconfirm", False, package_dir)
 
-    def install(self, args_as_string: str):
+    def install(self, args_as_list: List[str]):
         """
         Install this package
 
-        :param args_as_string: Args for pacman
+        :param args_as_list: Args for pacman
         """
         build_dir = Package.get_build_dir(os.path.join(Package.cache_dir, self.pkgbase))
 
@@ -1118,7 +1118,7 @@ class Package:
             raise InvalidInput("package file of {} not available".format(self.name))
 
         # install
-        pacman("{} {}".format(args_as_string, package_install_file), False, dir_to_execute=build_dir)
+        pacman(args_as_list.extend([package_install_file]), False, dir_to_execute=build_dir)
 
 
 class System:

--- a/src/aurman/parse_args.py
+++ b/src/aurman/parse_args.py
@@ -101,38 +101,40 @@ class PacmanArgs:
         self.operation: PacmanOperations = None
         self.targets: Sequence[str] = []  # contains the targets, e.g. the packages
         self.invalid_args: List[str] = []  # contains unknown parameters
-
-    def __repr__(self):
-        return_string = ""
+    
+    def as_list(self) -> Sequence[str]:
+        return_list = []
 
         for name, value in self.__dict__.items():
             if not value or name == "invalid_args":
                 continue
 
             if name == "operation":
-                return_string += " " + "--{}".format(value.value)
+                return_list.append("--{}".format(value.value))
 
             elif name == "targets":
-                return_string += " " + " ".join(value)
+                return_list.extend(value)
 
             else:
                 if pacman_options[name][2] and self.operation not in pacman_options[name][2]:
                     continue
 
                 if len(name) >= 2:
-                    return_string += " " + "--{}".format(name)
+                    return_list.append("--{}".format(name))
                 else:
-                    return_string += " " + "-{}".format(name)
+                    return_list.append("-{}".format(name))
                 if not isinstance(value, bool) and not pacman_options[name][1] == 0:
-                    return_string += " " + " ".join(value)
+                    return_list.extend(value)
                 # dirty hack for things like -yy or -cc
                 elif not isinstance(value, bool):
                     if len(name) >= 2:
-                        return_string += " " + "--{}".format(name)
+                        return_list.append("--{}".format(name))
                     else:
-                        return_string += " " + "-{}".format(name)
+                        return_list.append("-{}".format(name))
+        return return_list
 
-        return return_string.strip()
+    def __repr__(self):
+        return " ".join(self.as_list())
 
 
 def parse_pacman_args(args: Sequence[str]) -> 'PacmanArgs':

--- a/src/aurman/utilities.py
+++ b/src/aurman/utilities.py
@@ -3,16 +3,17 @@ import threading
 import time
 from pyalpm import vercmp
 from subprocess import run, DEVNULL
-from typing import Tuple, Sequence
+from typing import Tuple, Sequence, List
 
 import regex
 
 from aurman.aur_utilities import get_aur_info
 from aurman.coloring import Colors, aurman_error, aurman_question
 from aurman.own_exceptions import InvalidInput
+from aurman.wrappers import pacman
 
 
-def search_and_print(names: Sequence[str], installed_system, pacman_params: str, repo: bool, aur: bool):
+def search_and_print(names: Sequence[str], installed_system, pacman_params: List[str], repo: bool, aur: bool):
     """
     Searches for something and prints the results
 
@@ -29,9 +30,9 @@ def search_and_print(names: Sequence[str], installed_system, pacman_params: str,
         # escape for pacman
         to_escape = list("()+?|{}")
         for char in to_escape:
-            pacman_params = pacman_params.replace(char, "\{}".format(char))
+            pacman_params = [param.replace(char, "\{}".format(char)) for param in pacman_params]
 
-        run("pacman {}".format(pacman_params), shell=True)
+        pacman(pacman_params, False)
 
     if not repo:
         # see: https://docs.python.org/3/howto/regex.html

--- a/src/aurman/wrappers.py
+++ b/src/aurman/wrappers.py
@@ -76,35 +76,30 @@ def expac(option: str, formatting: Sequence[str], targets: Sequence[str]) -> Lis
     return return_list
 
 
-def pacman(options_as_string: str, fetch_output: bool, dir_to_execute: str = None, sudo: bool = True) -> List[str]:
+def pacman(options: List[str], fetch_output: bool, dir_to_execute: str = None, sudo: bool = True) -> List[str]:
     """
     pacman wrapper. see: https://www.archlinux.org/pacman/pacman.8.html
-    provide the pacman options as string via "options_as_string".
+    provide the pacman options as a list via "options".
     e.g. "-Syu package1 package2"
 
-    :param options_as_string:   the pacman options as string
+    :param options:             the pacman options
     :param fetch_output:        True if you want to receive the output of pacman, False otherwise
     :param dir_to_execute:      if you want to execute the pacman command in a specific directory, provide the directory
     :param sudo:                True if you want to execute pacman with sudo, False otherwise
     :return:                    empty list in case of "fetch_output"=False, otherwise the lines of the pacman output as list.
                                 one line of output is one item in the list.
     """
+    pacman_query = ["pacman"] + options
     if sudo:
-        pacman_query = "sudo pacman {}".format(options_as_string)
-    else:
-        pacman_query = "pacman {}".format(options_as_string)
+        pacman_query = ["sudo"] + pacman_query
 
+    run_kwargs = dict(shell=True)
     if fetch_output:
-        if dir_to_execute is not None:
-            pacman_return = run(pacman_query, shell=True, stdout=PIPE, stderr=DEVNULL, universal_newlines=True,
-                                cwd=dir_to_execute)
-        else:
-            pacman_return = run(pacman_query, shell=True, stdout=PIPE, stderr=DEVNULL, universal_newlines=True)
-    else:
-        if dir_to_execute is not None:
-            pacman_return = run(pacman_query, shell=True, cwd=dir_to_execute)
-        else:
-            pacman_return = run(pacman_query, shell=True)
+        run_kwargs.update(stdout=PIPE, stderr=DEVNULL, universal_newlines=True)
+    if dir_to_execute is not None:
+        run_kwargs.update(cwd=dir_to_execute)
+    
+    pacman_return = run(pacman_query, **run_kwargs)
 
     if pacman_return.returncode != 0:
         logging.error("pacman query {} failed".format(pacman_query))

--- a/src/unit_tests/test_parse_pacman_args.py
+++ b/src/unit_tests/test_parse_pacman_args.py
@@ -44,9 +44,9 @@ class TestParse_pacman_args(TestCase):
         self.assertEqual(['something'], ret_val.clean)
         self.assertEqual(True, ret_val.sysupgrade)
 
-        self.assertEqual(2, str(ret_val).count("--clean"))
-        self.assertEqual(1, str(ret_val).count("--sysupgrade"))
-        self.assertEqual(1, str(ret_val).count("--refresh"))
+        self.assertEqual(2, ret_val.as_list().count("--clean"))
+        self.assertEqual(1, ret_val.as_list().count("--sysupgrade"))
+        self.assertEqual(1, ret_val.as_list().count("--refresh"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Compare
```
aurman -Qi --cachedir "/tmp/with spaces" aurman-git
#actual  : pacman -Qi --cachedir "/tmp/with" "spaces" aurman-git
#expected: pacman -Qi --cachedir "/tmp/with spaces" aurman-git
```