### PR TITLE
Switch expac-git back to expac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN sudo sh -c "sed -i '/MAKEFLAGS=/s/^.*$/MAKEFLAGS=\"-j\$(nproc)\"/' /etc/make
 RUN sudo sh -c "sed -i '/PKGEXT=/s/^.*$/PKGEXT=\".pkg.tar\"/' /etc/makepkg.conf"
 
 # aurman requirements and sysupgrade
-RUN sudo pacman --needed --noconfirm -Syu python reflector python-requests git python-regex
+RUN sudo pacman --needed --noconfirm -Syu python reflector python-requests git python-regex expac
 
 # new mirrors
 RUN sudo reflector --save /etc/pacman.d/mirrorlist --sort rate --age 1 --latest 10 --score 10 --number 5 --protocol http

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="AUR helper with almost pacman syntax"
 arch=('any')
 url="https://github.com/polygamma/aurman"
 license=('MIT')
-depends=('python' 'expac-git>=8.1.g5ae006f' 'python-requests' 'git' 'python-regex' 'pacman>=5.1')
+depends=('python' 'expac' 'python-requests' 'git' 'python-regex' 'pacman>=5.1')
 source=('aurman_sources::git+https://github.com/polygamma/aurman.git?signed#branch=master')
 md5sums=('SKIP')
 validpgpkeys=('4C3CE98F9579981C21CA1EC3465022E743D71E39') # Jonni Westphalen

--- a/PKGBUILD_NON_DEVEL
+++ b/PKGBUILD_NON_DEVEL
@@ -6,7 +6,7 @@ pkgdesc="AUR helper with almost pacman syntax"
 arch=('any')
 url="https://github.com/polygamma/aurman"
 license=('MIT')
-depends=('python' 'expac-git>=8.1.g5ae006f' 'python-requests' 'git' 'python-regex' 'pacman>=5.1')
+depends=('python' 'expac' 'python-requests' 'git' 'python-regex' 'pacman>=5.1')
 source=("aurman_sources::git+https://github.com/polygamma/aurman.git?signed#tag=${pkgver}")
 md5sums=('SKIP')
 validpgpkeys=('4C3CE98F9579981C21CA1EC3465022E743D71E39') # Jonni Westphalen

--- a/src/docker_tests/archive_tests.py
+++ b/src/docker_tests/archive_tests.py
@@ -7,10 +7,8 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac-git
-    test_command("git clone https://aur.archlinux.org/expac-git.git")
-    test_command("makepkg -si --needed --noconfirm", dir_to_execute=join(getcwd(), "expac-git"))
-    test_command("rm -rf expac-git/")
+    # install expac
+    test_command("sudo pacman -S expac")
 
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")

--- a/src/docker_tests/archive_tests.py
+++ b/src/docker_tests/archive_tests.py
@@ -7,9 +7,6 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac
-    test_command("sudo pacman -S expac")
-
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")
 

--- a/src/docker_tests/build_dir_tests.py
+++ b/src/docker_tests/build_dir_tests.py
@@ -6,9 +6,6 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac
-    test_command("sudo pacman -S expac")
-
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")
 

--- a/src/docker_tests/build_dir_tests.py
+++ b/src/docker_tests/build_dir_tests.py
@@ -6,10 +6,8 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac-git
-    test_command("git clone https://aur.archlinux.org/expac-git.git")
-    test_command("makepkg -si --needed --noconfirm", dir_to_execute=join(getcwd(), "expac-git"))
-    test_command("rm -rf expac-git/")
+    # install expac
+    test_command("sudo pacman -S expac")
 
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")

--- a/src/docker_tests/cache_tests.py
+++ b/src/docker_tests/cache_tests.py
@@ -6,9 +6,6 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac
-    test_command("sudo pacman -S expac")
-
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")
 

--- a/src/docker_tests/cache_tests.py
+++ b/src/docker_tests/cache_tests.py
@@ -6,10 +6,8 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac-git
-    test_command("git clone https://aur.archlinux.org/expac-git.git")
-    test_command("makepkg -si --needed --noconfirm", dir_to_execute=join(getcwd(), "expac-git"))
-    test_command("rm -rf expac-git/")
+    # install expac
+    test_command("sudo pacman -S expac")
 
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")

--- a/src/docker_tests/install_tests.py
+++ b/src/docker_tests/install_tests.py
@@ -5,10 +5,8 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac-git
-    test_command("git clone https://aur.archlinux.org/expac-git.git")
-    test_command("makepkg -si --needed --noconfirm", dir_to_execute=join(getcwd(), "expac-git"))
-    test_command("rm -rf expac-git/")
+    # install expac
+    test_command("sudo pacman -S expac")
 
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")

--- a/src/docker_tests/install_tests.py
+++ b/src/docker_tests/install_tests.py
@@ -5,9 +5,6 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac
-    test_command("sudo pacman -S expac")
-
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")
 

--- a/src/docker_tests/pkgdest_tests.py
+++ b/src/docker_tests/pkgdest_tests.py
@@ -5,10 +5,8 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac-git
-    test_command("git clone https://aur.archlinux.org/expac-git.git")
-    test_command("makepkg -si --needed --noconfirm", dir_to_execute=join(getcwd(), "expac-git"))
-    test_command("rm -rf expac-git/")
+    # install expac
+    test_command("sudo pacman -S expac")
 
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")

--- a/src/docker_tests/pkgdest_tests.py
+++ b/src/docker_tests/pkgdest_tests.py
@@ -5,9 +5,6 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac
-    test_command("sudo pacman -S expac")
-
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")
 

--- a/src/docker_tests/testing_repo_tests.py
+++ b/src/docker_tests/testing_repo_tests.py
@@ -6,9 +6,6 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac
-    test_command("sudo pacman -S expac")
-
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")
 

--- a/src/docker_tests/testing_repo_tests.py
+++ b/src/docker_tests/testing_repo_tests.py
@@ -6,10 +6,8 @@ from sys import exit
 from docker_tests.test_utils import CurrentTest, test_command
 
 if __name__ == '__main__':
-    # install expac-git
-    test_command("git clone https://aur.archlinux.org/expac-git.git")
-    test_command("makepkg -si --needed --noconfirm", dir_to_execute=join(getcwd(), "expac-git"))
-    test_command("rm -rf expac-git/")
+    # install expac
+    test_command("sudo pacman -S expac")
 
     # install aurman
     test_command("sudo python setup.py install --optimize=1", "/home/aurman/aurman-git")


### PR DESCRIPTION
Closes https://github.com/polygamma/aurman/issues/181

As aur/expac-git uses `provides=('expac')` instead of `provides=("expac=$pkgver")`, versioned dependency can't be used in aurman.