### PR TITLE
Comment out comments in the github issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,25 +1,27 @@
+<!--
 THIS TEMPLATE IS FOR BUG REPORTS,
 YOU DO NOT HAVE TO USE IT FOR FEATURE REQUESTS.
 
 MAKE NEVERTHELESS SURE, THAT THE FEATURE REQUEST IS WORDED IN A MEANINGFUL WAY
+-->
 
 ## Description
-_Provide a general summary of the issue in the Title above_
+<!-- _Provide a general summary of the issue in the Title above_ -->
 
 ## Expected Behavior
-_Tell what should happen_
+<!-- _Tell what should happen_ -->
 
 ## Current Behavior
-_Tell what happens instead of the expected behavior_
+<!-- _Tell what happens instead of the expected behavior_ -->
 
 ## Possible Solution
-_Not obligatory, but suggest a fix/reason for the bug_
+<!-- _Not obligatory, but suggest a fix/reason for the bug_ -->
 
 ## Version of aurman you are using
-_Output of `aurman -V` or `aurman --version`_
+<!-- _Output of `aurman -V` or `aurman --version`_ -->
 
 ## Steps to Reproduce
-_Provide an unambiguous set of steps to reproduce this bug_
+<!-- _Provide an unambiguous set of steps to reproduce this bug_ -->
 
 1.
 2.
@@ -27,11 +29,12 @@ _Provide an unambiguous set of steps to reproduce this bug_
 4.
 
 ## Read the README
-_Confirm, that you have read the entire README_
+<!-- _Confirm, that you have read the entire README_ -->
 
 ## Running linux distribution
-_Write, which linux distribution you are using.
+<!-- _Write, which linux distribution you are using.
 If you are using anything besides Arch Linux, e.g. Antergos or Manjaro, you may simply not submit this issue, because those are unsupported_
 
 > **Notice**: If you do not fill out one of the fields, without mentioning **why** you left it out, the issue will be closed without any comment.
 You may also be banned from this repository without further warning.
+-->


### PR DESCRIPTION
They still appear when creating an issue, but they don't appear in the rendered display.