### PR TITLE
Add pyalpm requirement to setup.py too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ services:
   - docker
 before_install:
   - docker build -t aurman_docker .
-install:
-  - python setup.py install
 script:
-  - python src/unit_tests/test_split_query_helper.py
-  - python src/unit_tests/test_parse_pacman_args.py
   - docker run aurman_docker install_tests
   - docker run aurman_docker cache_tests
   - docker run aurman_docker build_dir_tests
   - docker run aurman_docker testing_repo_tests
   - docker run aurman_docker pkgdest_tests
   - docker run aurman_docker archive_tests
+  - docker run aurman_docker unit_tests/test_split_query_helper.py
+  - docker run aurman_docker unit_tests/test_parse_pacman_args.py
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
         ]
     },
 
-    install_requires=['requests', 'regex']
+    install_requires=['pyalpm', 'requests', 'regex']
 )

--- a/src/docker_tests/execute_test.sh
+++ b/src/docker_tests/execute_test.sh
@@ -7,5 +7,9 @@ source /home/aurman/.bash_profile
 source /home/aurman/.bashrc
 
 # call test
-python -m docker_tests.$1
+if [[ -f $1 ]]; then
+    python "$1"
+else
+    python -m docker_tests.$1
+fi
 exit $?


### PR DESCRIPTION
Seems to have been forgotten.

I guess error messages about pycman being unable to be imported, when clueless users try installing aurman with -Udd to ignore pyalpm dependencies, are probably less useful than setuptools messages saying the pyalpm distribution is missing.

Also makes it work better with `pip install --user .` (well, despite neither aurman nor pyalpm being on PyPI, but that's hardly a requirement of setuptools, just an option for easier autodiscovery).