### PR TITLE
Add help menu for aurmansolver

### DIFF
--- a/src/aurman/help_printing.py
+++ b/src/aurman/help_printing.py
@@ -172,3 +172,66 @@ only_aurman_points.append(HelpOption(["--optimistic_versioning"],
                                      "assume that the dependency is fulfilled"))
 only_aurman_points.append(HelpOption(["--rebuild"],
                                      "Always rebuild packages before installing them"))
+# aurmansolver help
+aurmansolver_help = Help([])
+
+solver_usage_title = "Usage"
+solver_usage = "aurmansolver <operation> [options] [targets]\n    see also https://www.archlinux.org/pacman/pacman.8.html"
+aurmansolver_help.points.append(HelpPoint(solver_usage_title, (solver_usage,)))
+
+# description
+solver_description_title = "Description"
+solver_description = "aurmansolver is meant as a {}. " \
+              "The operation must be {} or {}.\n    " \
+              "Valid solutions will be shown in {}, allowing " \
+              "the output to be parsed by external programs." \
+                                         .format(Colors.BOLD("dependency solver"),
+                                         Colors.BOLD(Colors.LIGHT_GREEN("--sync")),
+                                         Colors.BOLD(Colors.LIGHT_GREEN("-S")),
+                                         Colors.BOLD("JSON"))
+aurmansolver_help.points.append(HelpPoint(solver_description_title, (solver_description,)))
+
+# aurmansolver exclusive options
+only_solver = "aurmansolver options"
+only_solver_points = []
+aurmansolver_help.points.append(HelpPoint(only_solver, only_solver_points))
+
+only_solver_points.append("These options effect how the dependency resolving is " \
+                                        "calculated but {} actions will " \
+                                        "actually be performed.\n" \
+                                        .format(Colors.BOLD(Colors.LIGHT_RED("no"))))
+
+only_solver_points.append(HelpOption(["--devel"],
+                                     "Will fetch current development packages versions"))
+only_solver_points.append(HelpOption(["--deep_search"],
+                                     "Dependency solving will ignore currently "
+                                     "fulfilled dependencies of your system"))
+only_solver_points.append(HelpOption(["--aur"],
+                                     "Do things only for aur"))
+only_solver_points.append(HelpOption(["--repo"],
+                                     "Do things only for regular repos"))
+only_solver_points.append(HelpOption(["--domain"],
+                                     "Change the base url for aur requests (https://aur.archlinux.org is the default)"))
+only_solver_points.append(HelpOption(["--holdpkg"],
+                                     "Specify packages which must not be removed - "
+                                     "multiple packages are space separated"))
+only_solver_points.append(HelpOption(["--holdpkg_conf"],
+                                     "Append packages from the pacman.conf to"
+                                     " {}".format(Colors.LIGHT_GREEN("--holdpkg"))))
+only_solver_points.append(HelpOption(["--ignore"],
+                                    "Directs pacman to ignore upgrades of package even if there is one available"))
+only_solver_points.append(HelpOption(["--ignoregroup"],
+                                    "Directs pacman to ignore upgrades of all packages in group, "
+                                    "even if there is one available."))
+only_solver_points.append(HelpOption(["-u", "--sysupgrade"],
+                                    "Upgrades all packages that are out-of-date"))
+only_solver_points.append(HelpOption(["--optimistic_versioning"],
+                                     "In case of an unknown version of a provider for a versioned dependency, "
+                                     "assume that the dependency is fulfilled"))
+only_solver_points.append(HelpOption(["--rebuild"],
+                                     "Always rebuild packages before installing them"))
+only_solver_points.append(HelpOption(["--show_unkown"],
+                                     "Prints packages that are not know either "
+                                     "in the repos or the aur. Packages will be "
+                                     "{} instead of JSON formatted"
+                                     .format(Colors.BOLD("new line separated"))))

--- a/src/aurman/main_solver.py
+++ b/src/aurman/main_solver.py
@@ -7,7 +7,8 @@ from typing import Sequence, Set, Dict, List
 from pycman.config import PacmanConfig
 
 from aurman.classes import System, Package, PossibleTypes
-from aurman.coloring import aurman_error, Colors
+from aurman.coloring import aurman_error, aurman_note, Colors
+from aurman.help_printing import aurmansolver_help
 from aurman.own_exceptions import InvalidInput
 from aurman.parse_args import parse_pacman_args, PacmanOperations
 from aurman.parsing_config import read_config, AurmanConfig
@@ -64,7 +65,19 @@ def parse_parameters(args: List[str]) -> 'PacmanArgs':
     try:
         return parse_pacman_args(args)
     except InvalidInput:
+        aurman_note("aurmansolver --help or aurmansolver -h")
         sys.exit(1)
+
+def show_help() -> None:
+    """
+    shows the help of aurmansolver
+    """
+    # remove colors in case of not terminal
+    if sys.stdout.isatty():
+        print(aurmansolver_help)
+    else:
+        print(Colors.strip_colors(str(aurmansolver_help)))
+    sys.exit(0)
 
 class SolutionEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -91,6 +104,9 @@ def process(args):
 
     # parse parameters of user
     pacman_args = parse_parameters(args)
+
+    if pacman_args.operation is PacmanOperations.HELP:
+        show_help()
 
     if pacman_args.operation is not PacmanOperations.SYNC or pacman_args.invalid_args:
         sys.exit(1)

--- a/src/aurman/main_solver.py
+++ b/src/aurman/main_solver.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import sys
-from typing import Sequence, Set, Dict
+from typing import Sequence, Set, Dict, List
 
 from pycman.config import PacmanConfig
 
@@ -55,6 +55,16 @@ def sanitize_user_input(user_input: Sequence[str], system: 'System') -> Set[str]
 
     return sanitized_names
 
+def parse_parameters(args: List[str]) -> 'PacmanArgs':
+    """
+    parses the parameters of the user
+    :param args: the args to parse
+    :return: the parsed args
+    """
+    try:
+        return parse_pacman_args(args)
+    except InvalidInput:
+        sys.exit(1)
 
 class SolutionEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -80,7 +90,7 @@ def process(args):
         sys.exit(1)
 
     # parse parameters of user
-    pacman_args = parse_pacman_args(args)
+    pacman_args = parse_parameters(args)
 
     if pacman_args.operation is not PacmanOperations.SYNC or pacman_args.invalid_args:
         sys.exit(1)


### PR DESCRIPTION
Help menus are always nice. Now we can check the flags from the command line instead of having to visit https://github.com/polygamma/aurman/wiki/Using-aurman-as-dependency-solver every time.