### PR TITLE
Error handling on broken locale config

### DIFF
--- a/src/aurman/main.py
+++ b/src/aurman/main.py
@@ -1299,8 +1299,13 @@ def process(args):
 
 
 def main():
-    from locale import setlocale, LC_ALL
-    setlocale(LC_ALL, '')  # initialize locales because python doesn't
+    from locale import setlocale, LC_ALL, Error
+    try:
+        # initialize locales because python doesn't
+        setlocale(LC_ALL, '')
+    except Error:
+        # Remain at the default 'C' locale on failure
+        logging.warning('Failed to set locale; using default locale.')
 
     try:
         # auto completion


### PR DESCRIPTION
aurman would crash if setting the locale failed, e.g. due to a user's misconfiguration.  This PR catches such a failure and uses the C locale instead, and logs a warning.