### PR TITLE
minor convenience improvements and bugfix

### DIFF
--- a/src/aurman/help_printing.py
+++ b/src/aurman/help_printing.py
@@ -137,7 +137,7 @@ aurman_help.points.append(HelpPoint(only_aurman, only_aurman_points))
 
 only_aurman_points.append(HelpOption(["--noedit"],
                                      "Will not show changes of PKGBUILDs, .install and other relevant files"))
-only_aurman_points.append(HelpOption(["--always_edit"],
+only_aurman_points.append(HelpOption(["-e", "--always_edit"],
                                      "Lets the user edit the files of packages, even if there are no new changes"))
 only_aurman_points.append(HelpOption(["--show_changes"],
                                      "Will show changes of PKGBUILDs, .install and other relevant files without asking"))
@@ -150,7 +150,7 @@ only_aurman_points.append(HelpOption(["--pgp_fetch"],
                                      "Fetches needed pgp keys without asking the user"))
 only_aurman_points.append(HelpOption(["--keyserver"],
                                      "You may specify a keyserver to fetch the pgp keys from"))
-only_aurman_points.append(HelpOption(["--aur"],
+only_aurman_points.append(HelpOption(["-a", "--aur"],
                                      "-Ss restricted to AUR packages and -Sc restricted to aurman cache"))
 only_aurman_points.append(HelpOption(["--repo"],
                                      "-Ss restricted to repo packages and -Sc restricted to pacman cache"))
@@ -172,7 +172,7 @@ only_aurman_points.append(HelpOption(["--optimistic_versioning"],
                                      "assume that the dependency is fulfilled"))
 only_aurman_points.append(HelpOption(["--ignore_versioning"],
                                      "Assume all versioned dependencies to be fulfilled"))
-only_aurman_points.append(HelpOption(["--rebuild"],
+only_aurman_points.append(HelpOption(["-r", "--rebuild"],
                                      "Always rebuild packages before installing them"))
 only_aurman_points.append(HelpOption(["--sort_by_name"],
                                      "Sort -Ss AUR results by name"))

--- a/src/aurman/main.py
+++ b/src/aurman/main.py
@@ -114,7 +114,10 @@ def get_holdpkgs(pacman_args: 'PacmanArgs') -> List[str]:
     not_remove = pacman_args.holdpkg  # list containing the specified packages for --holdpkg
     # if --holdpkg_conf append holdpkg from pacman.conf
     if pacman_args.holdpkg_conf:
-        not_remove.extend(PacmanConfig(conf="/etc/pacman.conf").options['HoldPkg'])
+        try:
+            not_remove.extend(PacmanConfig(conf="/etc/pacman.conf").options['HoldPkg'])
+        except KeyError:
+            pass #pacmanconf does not contain "HoldPkg" or it is a nullstr
     # remove duplicates
     return list(set(not_remove))
 

--- a/src/aurman/main_solver.py
+++ b/src/aurman/main_solver.py
@@ -196,7 +196,10 @@ def process(args):
     not_remove = pacman_args.holdpkg  # list containing the specified packages for --holdpkg
     # if --holdpkg_conf append holdpkg from pacman.conf
     if pacman_args.holdpkg_conf:
-        not_remove.extend(PacmanConfig(conf="/etc/pacman.conf").options['HoldPkg'])
+        try:
+            not_remove.extend(PacmanConfig(conf="/etc/pacman.conf").options['HoldPkg'])
+        except KeyError:
+            pass #pacmanconf does not contain "HoldPkg" or it is a nullstr
     # remove duplicates
     not_remove = list(set(not_remove))
 

--- a/src/aurman/parse_args.py
+++ b/src/aurman/parse_args.py
@@ -61,30 +61,48 @@ pacman_options = {
 
     # to sort -Ss results
     "sort_by_name": ("sort_by_name", 0, (PacmanOperations.AURMAN,), False, False),
+    "sort-by-name": ("sort_by_name", 0, (PacmanOperations.AURMAN,), False, False),
     "sort_by_votes": ("sort_by_votes", 0, (PacmanOperations.AURMAN,), False, False),
+    "sort-by-votes": ("sort_by_votes", 0, (PacmanOperations.AURMAN,), False, False),
     "sort_by_popularity": ("sort_by_popularity", 0, (PacmanOperations.AURMAN,), False, False),
+    "sort-by-popularity": ("sort_by_popularity", 0, (PacmanOperations.AURMAN,), False, False),
 
     # regular aurman params
     "noedit": ("noedit", 0, (PacmanOperations.AURMAN,), False, False),
     "always_edit": ("always_edit", 0, (PacmanOperations.AURMAN,), False, False),
+    "always-edit": ("always_edit", 0, (PacmanOperations.AURMAN,), False, False),
+    "e": ("always_edit", 0, (PacmanOperations.AURMAN,), False, False), #as in pacaur
     "show_changes": ("show_changes", 0, (PacmanOperations.AURMAN,), False, False),
+    "show-changes": ("show_changes", 0, (PacmanOperations.AURMAN,), False, False),
     "devel": ("devel", 0, (PacmanOperations.AURMAN,), False, False),
     "deep_search": ("deep_search", 0, (PacmanOperations.AURMAN,), False, False),
+    "deep-search": ("deep_search", 0, (PacmanOperations.AURMAN,), False, False),
     "pgp_fetch": ("pgp_fetch", 0, (PacmanOperations.AURMAN,), False, False),
+    "pgp-fetch": ("pgp_fetch", 0, (PacmanOperations.AURMAN,), False, False),
     "keyserver": ("keyserver", 1, (PacmanOperations.AURMAN,), False, False),
     "aur": ("aur", 0, (PacmanOperations.AURMAN,), False, False),
+    "a": ("aur", 0, (PacmanOperations.AURMAN,), False, False), #akin to pacaur, not like yaourt
     "repo": ("repo", 0, (PacmanOperations.AURMAN,), False, False),
     "domain": ("domain", 1, (PacmanOperations.AURMAN,), False, False),
     "solution_way": ("solution_way", 0, (PacmanOperations.AURMAN,), False, False),
+    "solution-way": ("solution_way", 0, (PacmanOperations.AURMAN,), False, False),
     "holdpkg": ("holdpkg", 2, (PacmanOperations.AURMAN,), False, False),
     "holdpkg_conf": ("holdpkg_conf", 0, (PacmanOperations.AURMAN,), False, False),
+    "holdpkg-conf": ("holdpkg_conf", 0, (PacmanOperations.AURMAN,), False, False),
     "do_everything": ("do_everything", 0, (PacmanOperations.AURMAN,), False, False),
+    "do-everything": ("do_everything", 0, (PacmanOperations.AURMAN,), False, False),
     "optimistic_versioning": ("optimistic_versioning", 0, (PacmanOperations.AURMAN,), False, False),
+    "optimistic-versioning": ("optimistic_versioning", 0, (PacmanOperations.AURMAN,), False, False),
     "ignore_versioning": ("ignore_versioning", 0, (PacmanOperations.AURMAN,), False, False),
+    "ignore-versioning": ("ignore_versioning", 0, (PacmanOperations.AURMAN,), False, False),
     "rebuild": ("rebuild", 0, (PacmanOperations.AURMAN,), False, False),
+    "r": ("rebuild", 0, (PacmanOperations.AURMAN,), False, False),
     "skip_news": ("skip_news", 0, (PacmanOperations.AURMAN,), False, False),
+    "skip-news": ("skip_news", 0, (PacmanOperations.AURMAN,), False, False),
     "skip_new_locations": ("skip_new_locations", 0, (PacmanOperations.AURMAN,), False, False),
+    "skip-new-locations": ("skip_new_locations", 0, (PacmanOperations.AURMAN,), False, False),
     "devel_skip_deps": ("devel_skip_deps", 0, (PacmanOperations.AURMAN,), False, False)
+    "devel-skip-deps": ("devel_skip_deps", 0, (PacmanOperations.AURMAN,), False, False)
 }
 
 pacman_operations = {


### PR DESCRIPTION
* added one-letter pacaur-like abbreviations for most-used Sync options:
  - -e -> --always_edit
  - -a -> --aur
  - -r  -> --rebuild

* added skewer-case aliases for all aurman-introduced options (a widely accepted UNIX convention to which pacman seems to adhere as well)
* fixed exception when using --holdpkg_conf option without/with empty HoldPkg directive in /etc/pacman.conf