### PR TITLE
fixed bug due to requests urlencoding of URLs

### DIFF
--- a/src/aurman/aur_utilities.py
+++ b/src/aurman/aur_utilities.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Sequence, List, Dict
 from urllib.parse import quote_plus
+from urllib.request import urlopen
 
 import requests
 
@@ -46,17 +47,11 @@ def get_aur_info(package_names: Sequence[str], search: bool = False, by_name: bo
     results_list = []
     for query_parameters in queries_parameters:
         try:
-            results_list.extend(
-                json.loads(
-                    requests.get(
-                        "{}{}".format(
-                            query_url,
-                            ''.join(["{}{}".format(query_prefix, parameter) for parameter in query_parameters])
-                        ),
-                        timeout=AurVars.aur_timeout
-                    ).text
-                )['results']
-            )
+            url = "{}{}".format(
+                    query_url,
+                    ''.join(["{}{}".format(query_prefix, parameter) for parameter in query_parameters]))
+            with urlopen(url, timeout=AurVars.aur_timeout) as response:
+                results_list.extend(json.loads(response.read())['results'])
         except requests.exceptions.RequestException:
             logging.error("Connection problem while requesting AUR info for {}".format(package_names), exc_info=True)
             raise ConnectionProblem("Connection problem while requesting AUR info for {}".format(package_names))


### PR DESCRIPTION
The problem is that in `aurman.wrappers.split_query_helper` you split the package list according to the maximum URL length the Aurweb RPC interface can accept (that in the code appears to have been hardcoded to 8000, I'm not sure about how this value has been devised). 
Unfortunately the **requests** library actually calls `urllib.parse.quote` on the URL you give to it and [there seems to be no way to prevent it](https://stackoverflow.com/questions/23496750/how-to-prevent-python-requests-from-percent-encoding-my-urls), so the actual URL sent to the server is actually bigger than the size returned by `split_query_helper`. 

I noticed it because because I have several tens of custom packages on my machine and I was getting 415 from the aurweb API (but the same request succeeded when performed by `curl`).

The proposed solution is just to avoid using **requests** in that particular point of the code to avoid the URL quoting and just fallback to `urllib` (which, as far as I know, is *requests*'s underlying implementation)