### PR TITLE
RFC: support doas (and maybe su)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ optimistic_versioning
 ignore_versioning
 skip_news
 skip_new_locations
+[privilege_escalation]
+# sudo
+escalation_command=sudo
+noninterative_params=--non-interactive
+test_params=-v
+
+# doas
+escalation_command=doas
+noninterative_params=-n
+test_params=/bin/test
+
+# su
+escalation_command=su
+# noninterative_params and test_params are not supported therefore sudo_loop is not
 ```
 
 > **Notice**: Use of `do_everything` is **not** recommended since the usage of this flag is in general not recommended.

--- a/src/aurman/aur_utilities.py
+++ b/src/aurman/aur_utilities.py
@@ -5,8 +5,10 @@ from urllib.error import URLError
 from urllib.parse import quote_plus
 from urllib.request import urlopen
 
+from aurman.coloring import Colors, aurman_error
 from aurman.own_exceptions import InvalidInput, ConnectionProblem
 from aurman.parsing_config import AurmanConfig
+from aurman.utilities import SearchSortBy
 from aurman.wrappers import split_query_helper
 
 
@@ -81,3 +83,108 @@ def is_devel(name: str) -> bool:
         return name in AurmanConfig.aurman_config['devel_packages']
 
     return False
+
+
+def search_and_print(names: Sequence[str], installed_system, pacman_params: 'PacmanArgs',
+                     repo: bool, aur: bool, sort_by: SearchSortBy):
+    """
+    Searches for something and prints the results
+
+    :param names:               The things to search for
+    :param installed_system:    A system containing the installed packages
+    :param pacman_params:       parameters for pacman as string
+    :param repo:                search only in repo
+    :param aur:                 search only in aur
+    :param sort_by:             according to which the results are to be sorted
+    """
+    if not names:
+        return
+
+    if not aur:
+        run(["pacman"] + pacman_params.args_as_list())
+
+    if not repo:
+        if sort_by is None:
+            sort_by = SearchSortBy.POPULARITY
+
+        # see: https://docs.python.org/3/howto/regex.html
+        regex_chars = list("^.+*?$[](){}\|")
+
+        regex_patterns = [regex.compile(name, regex.IGNORECASE) for name in names]
+        names_beginnings_without_regex = []
+        for name in names:
+            index_start = -1
+            index_end = len(name)
+            for i, char in enumerate(name):
+                if char not in regex_chars and index_start == -1:
+                    index_start = i
+                elif char in regex_chars and index_start != -1:
+                    # must be at least two consecutive non regex chars
+                    if i - index_start < 2:
+                        index_start = -1
+                        continue
+                    index_end = i
+                    break
+
+            if index_start == -1 or index_end - index_start < 2:
+                aurman_error(
+                    "Your query {} contains not enough non regex chars!".format(
+                        Colors.BOLD(Colors.LIGHT_MAGENTA(name))
+                    )
+                )
+                raise InvalidInput(
+                    "Your query {} contains not enough non regex chars!".format(
+                        Colors.BOLD(Colors.LIGHT_MAGENTA(name))
+                    )
+                )
+
+            names_beginnings_without_regex.append(name[index_start:index_end])
+
+        found_names = set(ret_dict['Name'] for ret_dict in get_aur_info([names_beginnings_without_regex[0]], True)
+                          if regex_patterns[0].findall(ret_dict['Name'])
+                          or isinstance(ret_dict['Description'], str)
+                          and regex_patterns[0].findall(ret_dict['Description']))
+
+        for i in range(1, len(names)):
+            found_names &= set(ret_dict['Name'] for ret_dict in get_aur_info([names_beginnings_without_regex[i]], True)
+                               if regex_patterns[i].findall(ret_dict['Name'])
+                               or isinstance(ret_dict['Description'], str)
+                               and regex_patterns[i].findall(ret_dict['Description']))
+
+        search_return = get_aur_info(found_names)
+
+        kwargs = {}
+        if sort_by in [SearchSortBy.POPULARITY, SearchSortBy.VOTES]:
+            kwargs.update(reverse=True)
+
+        if sort_by is SearchSortBy.POPULARITY:
+            kwargs.update(key=lambda x: float(x['Popularity']))
+        elif sort_by is SearchSortBy.VOTES:
+            kwargs.update(key=lambda x: int(x['NumVotes']))
+        elif sort_by is SearchSortBy.NAME:
+            kwargs.update(key=lambda x: str(x['Name']))
+
+        for ret_dict in sorted(search_return, **kwargs):
+            repo_with_slash = Colors.BOLD(Colors.LIGHT_MAGENTA("aur/"))
+            name = Colors.BOLD(ret_dict['Name'])
+            if ret_dict['OutOfDate'] is None:
+                version = Colors.BOLD(Colors.GREEN(ret_dict['Version']))
+            else:
+                version = Colors.BOLD(Colors.RED(ret_dict['Version']))
+
+            first_line = "{}{} {} ({}, {})".format(
+                repo_with_slash, name, version, ret_dict['NumVotes'], ret_dict['Popularity']
+            )
+            if ret_dict['Name'] in installed_system.all_packages_dict:
+                if version_comparison(
+                        ret_dict['Version'], "=", installed_system.all_packages_dict[ret_dict['Name']].version
+                ):
+                    first_line += " {}".format(Colors.BOLD(Colors.CYAN("[installed]")))
+                else:
+                    first_line += " {}".format(
+                        Colors.BOLD(Colors.CYAN("[installed: {}]".format(
+                            installed_system.all_packages_dict[ret_dict['Name']].version
+                        )))
+                    )
+            print(first_line)
+            print("    {}".format(ret_dict['Description']))

--- a/src/aurman/main.py
+++ b/src/aurman/main.py
@@ -15,7 +15,7 @@ import requests
 from dateutil.tz import tzlocal
 from pycman.config import PacmanConfig
 
-from aurman.aur_utilities import get_aur_info, AurVars
+from aurman.aur_utilities import get_aur_info, search_and_print, AurVars
 from aurman.bash_completion import possible_completions
 from aurman.classes import System, Package, PossibleTypes
 from aurman.coloring import aurman_error, aurman_status, aurman_note, Colors
@@ -23,8 +23,8 @@ from aurman.help_printing import aurman_help
 from aurman.own_exceptions import InvalidInput, ConnectionProblem
 from aurman.parse_args import PacmanOperations, parse_pacman_args, PacmanArgs
 from aurman.parsing_config import read_config, packages_from_other_sources, AurmanConfig
-from aurman.utilities import acquire_sudo, version_comparison, search_and_print, ask_user, strip_versioning_from_name, \
-    get_sudo_method, SudoLoop, SearchSortBy
+from aurman.utilities import acquire_sudo, version_comparison, ask_user, strip_versioning_from_name, get_sudo_method, \
+    SudoLoop, SearchSortBy
 from aurman.wrappers import pacman, expac
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(module)s - %(funcName)s - %(levelname)s - %(message)s')

--- a/src/aurman/main.py
+++ b/src/aurman/main.py
@@ -24,7 +24,7 @@ from aurman.own_exceptions import InvalidInput, ConnectionProblem
 from aurman.parse_args import PacmanOperations, parse_pacman_args, PacmanArgs
 from aurman.parsing_config import read_config, packages_from_other_sources, AurmanConfig
 from aurman.utilities import acquire_sudo, version_comparison, search_and_print, ask_user, strip_versioning_from_name, \
-    SudoLoop, SearchSortBy
+    get_sudo_method, SudoLoop, SearchSortBy
 from aurman.wrappers import pacman, expac
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(module)s - %(funcName)s - %(levelname)s - %(message)s')
@@ -42,10 +42,10 @@ def readconfig() -> None:
 
 def check_privileges() -> None:
     """
-    checks the privileges and exists in case of aurman being executed with sudo
+    checks the privileges and exists in case of aurman being executed with root permissions
     """
     if os.getuid() == 0:
-        aurman_error("Do not run aurman with sudo")
+        aurman_error("Do not run aurman with root permissions, e.g. using sudo")
         sys.exit(1)
 
 
@@ -97,7 +97,7 @@ def redirect_pacman(pacman_args: 'PacmanArgs', args: List[str]) -> None:
         if pacman_args.operation in [
             PacmanOperations.UPGRADE, PacmanOperations.REMOVE, PacmanOperations.DATABASE, PacmanOperations.FILES
         ]:
-            cmd = ["sudo", "pacman"]
+            cmd = [*get_sudo_method(), "pacman"]
         run(cmd + args)
     except InvalidInput:
         sys.exit(1)
@@ -774,6 +774,32 @@ def process(args):
     if 'miscellaneous' in AurmanConfig.aurman_config \
             and 'sudo_timeout' in AurmanConfig.aurman_config['miscellaneous']:
         SudoLoop.timeout = int(AurmanConfig.aurman_config['miscellaneous']['sudo_timeout'])
+
+    # configure privilege escalation method
+    if 'privilege_escalation' in AurmanConfig.aurman_config \
+            and 'escalation_command' in AurmanConfig.aurman_config['privilege_escalation']:
+        SudoLoop.interactive_command = AurmanConfig.aurman_config['privilege_escalation']['escalation_command'].split(', ')
+        if not sudo_acquired \
+                and ('noninterative_params' in AurmanConfig.aurman_config['privilege_escalation'] \
+                or 'test_params' in AurmanConfig.aurman_config['privilege_escalation']):
+            if 'noninterative_params' in AurmanConfig.aurman_config['privilege_escalation'] \
+                    and 'test_params' not in AurmanConfig.aurman_config['privilege_escalation']:
+                aurman_error('noninterative_params and test_params have both to be defined, or not')
+                sys.exit(1)
+            if 'noninterative_params' not in AurmanConfig.aurman_config['privilege_escalation'] \
+                    and 'test_params' in AurmanConfig.aurman_config['privilege_escalation']:
+                aurman_error('noninterative_params and test_params have both to be defined, or not')
+                sys.exit(1)
+            noninterative_params = AurmanConfig.aurman_config['privilege_escalation']['noninterative_params'].split(', ')
+            test_params = AurmanConfig.aurman_config['privilege_escalation']['test_params'].split(', ')
+            SudoLoop.noninteractive_command = [*SudoLoop.interactive_command, *noninterative_params]
+            SudoLoop.test_interative = [*SudoLoop.interactive_command, *test_params]
+            SudoLoop.test_noninterative = [*SudoLoop.interactive_command, *noninterative_params, *test_params]
+        else:
+            sudo_acquired = False
+            SudoLoop.noninteractive_command = None
+            SudoLoop.test_interative = None
+            SudoLoop.test_noninterative = None
 
     # change aur domain if configured by the user
     if pacman_args.domain:

--- a/src/aurman/main_solver.py
+++ b/src/aurman/main_solver.py
@@ -148,7 +148,7 @@ def process(args):
         sys.exit(1)
 
     if os.getuid() == 0:
-        aurman_error("Do not run aurman with sudo")
+        aurman_error("Do not run aurman with root permissions, e.g. using sudo")
         sys.exit(1)
 
     # parse parameters of user

--- a/src/aurman/utilities.py
+++ b/src/aurman/utilities.py
@@ -12,10 +12,8 @@ from typing import Tuple, Sequence
 
 import regex
 
-from aurman.aur_utilities import get_aur_info
-from aurman.coloring import Colors, aurman_error, aurman_question
+from aurman.coloring import aurman_error, aurman_question
 from aurman.own_exceptions import InvalidInput
-from aurman.parse_args import PacmanArgs
 
 
 class SudoLoop:
@@ -38,111 +36,6 @@ def get_sudo_method():
     if SudoLoop.noninteractive_command:
         return SudoLoop.noninteractive_command
     return SudoLoop.interactive_command
-
-
-def search_and_print(names: Sequence[str], installed_system, pacman_params: 'PacmanArgs',
-                     repo: bool, aur: bool, sort_by: SearchSortBy):
-    """
-    Searches for something and prints the results
-
-    :param names:               The things to search for
-    :param installed_system:    A system containing the installed packages
-    :param pacman_params:       parameters for pacman as string
-    :param repo:                search only in repo
-    :param aur:                 search only in aur
-    :param sort_by:             according to which the results are to be sorted
-    """
-    if not names:
-        return
-
-    if not aur:
-        run(["pacman"] + pacman_params.args_as_list())
-
-    if not repo:
-        if sort_by is None:
-            sort_by = SearchSortBy.POPULARITY
-
-        # see: https://docs.python.org/3/howto/regex.html
-        regex_chars = list("^.+*?$[](){}\|")
-
-        regex_patterns = [regex.compile(name, regex.IGNORECASE) for name in names]
-        names_beginnings_without_regex = []
-        for name in names:
-            index_start = -1
-            index_end = len(name)
-            for i, char in enumerate(name):
-                if char not in regex_chars and index_start == -1:
-                    index_start = i
-                elif char in regex_chars and index_start != -1:
-                    # must be at least two consecutive non regex chars
-                    if i - index_start < 2:
-                        index_start = -1
-                        continue
-                    index_end = i
-                    break
-
-            if index_start == -1 or index_end - index_start < 2:
-                aurman_error(
-                    "Your query {} contains not enough non regex chars!".format(
-                        Colors.BOLD(Colors.LIGHT_MAGENTA(name))
-                    )
-                )
-                raise InvalidInput(
-                    "Your query {} contains not enough non regex chars!".format(
-                        Colors.BOLD(Colors.LIGHT_MAGENTA(name))
-                    )
-                )
-
-            names_beginnings_without_regex.append(name[index_start:index_end])
-
-        found_names = set(ret_dict['Name'] for ret_dict in get_aur_info([names_beginnings_without_regex[0]], True)
-                          if regex_patterns[0].findall(ret_dict['Name'])
-                          or isinstance(ret_dict['Description'], str)
-                          and regex_patterns[0].findall(ret_dict['Description']))
-
-        for i in range(1, len(names)):
-            found_names &= set(ret_dict['Name'] for ret_dict in get_aur_info([names_beginnings_without_regex[i]], True)
-                               if regex_patterns[i].findall(ret_dict['Name'])
-                               or isinstance(ret_dict['Description'], str)
-                               and regex_patterns[i].findall(ret_dict['Description']))
-
-        search_return = get_aur_info(found_names)
-
-        kwargs = {}
-        if sort_by in [SearchSortBy.POPULARITY, SearchSortBy.VOTES]:
-            kwargs.update(reverse=True)
-
-        if sort_by is SearchSortBy.POPULARITY:
-            kwargs.update(key=lambda x: float(x['Popularity']))
-        elif sort_by is SearchSortBy.VOTES:
-            kwargs.update(key=lambda x: int(x['NumVotes']))
-        elif sort_by is SearchSortBy.NAME:
-            kwargs.update(key=lambda x: str(x['Name']))
-
-        for ret_dict in sorted(search_return, **kwargs):
-            repo_with_slash = Colors.BOLD(Colors.LIGHT_MAGENTA("aur/"))
-            name = Colors.BOLD(ret_dict['Name'])
-            if ret_dict['OutOfDate'] is None:
-                version = Colors.BOLD(Colors.GREEN(ret_dict['Version']))
-            else:
-                version = Colors.BOLD(Colors.RED(ret_dict['Version']))
-
-            first_line = "{}{} {} ({}, {})".format(
-                repo_with_slash, name, version, ret_dict['NumVotes'], ret_dict['Popularity']
-            )
-            if ret_dict['Name'] in installed_system.all_packages_dict:
-                if version_comparison(
-                        ret_dict['Version'], "=", installed_system.all_packages_dict[ret_dict['Name']].version
-                ):
-                    first_line += " {}".format(Colors.BOLD(Colors.CYAN("[installed]")))
-                else:
-                    first_line += " {}".format(
-                        Colors.BOLD(Colors.CYAN("[installed: {}]".format(
-                            installed_system.all_packages_dict[ret_dict['Name']].version
-                        )))
-                    )
-            print(first_line)
-            print("    {}".format(ret_dict['Description']))
 
 
 def split_name_with_versioning(name: str) -> Tuple[str, str, str]:

--- a/src/aurman/wrappers.py
+++ b/src/aurman/wrappers.py
@@ -4,6 +4,7 @@ from subprocess import run, PIPE, DEVNULL
 from typing import Sequence, List
 
 from aurman.own_exceptions import InvalidInput
+from aurman.utilities import get_sudo_method
 
 
 def split_query_helper(max_length: int, base_length_of_query: int, length_per_append: int, to_append: Sequence[str]) -> \
@@ -88,7 +89,7 @@ def pacman(options_as_list: List[str], fetch_output: bool, dir_to_execute: str =
                                 one line of output is one item in the list.
     """
     if sudo:
-        pacman_query = ["sudo", "pacman"]
+        pacman_query = [*get_sudo_method(), "pacman"]
     else:
         pacman_query = ["pacman"]
 


### PR DESCRIPTION
Hello polygamma,

I'm still using aurman and am very grateful for you to continue signing your commits (and releases)!
aurman is still the best AUR helper to me, thanks a ton for continuing!


Now to the actual changes:
aurman is one of the few programs without support for doas on my systems.
This is a quick shot at getting supporting doas in aurman, I can clean up if there's interest.

Notes
* A new member `sudo_method` was put into the `SudoLoop` class in utilities.py to store the chosen method to get root.
This might be a bit ugly to you, if not there were would you like it?
* There is now a bit of code duplication in `utilities.py`'s `acquire_sudo`, this can be merged, but might be less readable.
* I needed to move `search_and_print` from `utilities.py` to `aur_utilities.py` to prevent a dependencyloop
(loop was: aur_utilities => wrappers => utilities => aur_utilities)
This was put into a separate commit to make it more easy to read.
When I was fixing the other imports I also removed some unused ones.
* Basic support for also supporting `su` is implemented, but completely untested!
I could throw that out, guess there probably is not a lot of interest.
* I clarified some error messages, which were raised after testing for being root and then misinformed users about requiring sudo for that.
* Not all operations have been tested, I can ofc thoroughly test.
